### PR TITLE
Remove dead Stripe webhook and refresh session after checkout

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@
 - Billing
 - Webhook syncing to Convex
 
+> Entitlement sync is handled by WorkOS (via the [Stripe integration](https://workos.com/docs/authkit/add-ons/stripe)) — the app's only responsibility is [refreshing the session](https://workos.com/docs/user-management/entitlements) after checkout so new entitlements appear in the access token immediately. No app-side Stripe webhook is required for entitlements.
+
 ## Getting started
 
 ### Prerequisites

--- a/scripts/setup.ts
+++ b/scripts/setup.ts
@@ -275,28 +275,7 @@ async function setupConvex() {
   }
 }
 
-async function setupStripeWebhook(stripeApiKey: string, webhookUrl: string) {
-  console.log(`\n${chalk.bold('Setting up Stripe webhooks')}`);
-
-  const stripe = new Stripe(stripeApiKey);
-
-  try {
-    const endpoint = await stripe.webhookEndpoints.create({
-      enabled_events: ['checkout.session.completed'],
-      url: webhookUrl,
-    });
-
-    console.log(chalk.green('Stripe webhook created successfully'));
-
-    console.log('\nAdding Stripe endpoint signing secret as deployment variable in Convex');
-    await execAsync(`npx convex env set STRIPE_WEBHOOK_SECRET ${endpoint.secret}`);
-    console.log(chalk.green('Stripe endpoint signing secret set as deployment variable in Convex'));
-  } catch (error) {
-    console.log(chalk.red('Failed to create Stripe webhook'));
-    console.log(error);
-    process.exit(1);
-  }
-
+async function setStripeApiKeyInConvex(stripeApiKey: string) {
   try {
     console.log('\nAdding Stripe API key as deployment variable in Convex');
     await execAsync(`npx convex env set STRIPE_API_KEY ${stripeApiKey}`);
@@ -378,7 +357,10 @@ async function main() {
   const convexUrl = env.match(/NEXT_PUBLIC_CONVEX_URL=(.*)/)?.[1];
   const webhookUrl = convexUrl?.replace('.cloud', '.site');
 
-  await setupStripeWebhook(STRIPE_API_KEY, webhookUrl + '/stripe-webhook');
+  // Entitlement sync is handled by WorkOS via the Stripe (Entitlements)
+  // integration — the app does NOT need its own Stripe webhook. We only need
+  // the Stripe API key available to Convex (used by convex/stripe.ts).
+  await setStripeApiKeyInConvex(STRIPE_API_KEY);
   await setupWorkOSWebhook(WORKOS_API_KEY, webhookUrl + '/workos-webhook');
 
   console.log('\n🎉 Setup completed successfully!');

--- a/src/app/api/subscribe/route.ts
+++ b/src/app/api/subscribe/route.ts
@@ -49,6 +49,11 @@ export const POST = async (req: NextRequest) => {
       stripeCustomerId: customer.id,
     });
 
+    // Entitlements are provisioned onto the organization's access token by
+    // WorkOS automatically (via the Stripe Entitlements integration) once the
+    // Stripe customer ID is set on the org above. No app-side Stripe webhook is
+    // required. We tag the success URL so /dashboard can refresh the session and
+    // surface the new entitlements immediately instead of on the next login.
     const session = await stripe.checkout.sessions.create({
       customer: customer.id,
       billing_address_collection: 'auto',
@@ -59,7 +64,7 @@ export const POST = async (req: NextRequest) => {
         },
       ],
       mode: 'subscription',
-      success_url: `${process.env.NEXT_PUBLIC_BASE_URL}/dashboard`,
+      success_url: `${process.env.NEXT_PUBLIC_BASE_URL}/dashboard?checkout=success`,
       cancel_url: `${process.env.NEXT_PUBLIC_BASE_URL}/pricing`,
     });
 

--- a/src/app/dashboard/checkout-success-refresh.tsx
+++ b/src/app/dashboard/checkout-success-refresh.tsx
@@ -16,7 +16,13 @@ export function CheckoutSuccessRefresh() {
     let cancelled = false;
 
     const refresh = async () => {
-      await refreshAuthkitSession();
+      try {
+        await refreshAuthkitSession();
+      } catch {
+        // If the refresh fails, still drop the marker below so we don't retry on
+        // every page load. The entitlements will appear on the next natural
+        // session refresh.
+      }
       if (cancelled) return;
 
       // Drop the ?checkout=success marker and re-render with fresh entitlements.

--- a/src/app/dashboard/checkout-success-refresh.tsx
+++ b/src/app/dashboard/checkout-success-refresh.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { refreshAuthkitSession } from '@/actions/refreshAuthkitSession';
+
+// After a successful Stripe checkout, refresh the AuthKit session so the
+// entitlements WorkOS just provisioned appear in the access token now, rather
+// than on the user's next login/natural refresh. `refreshAuthkitSession` sets
+// cookies, so it must run from a client-triggered server action rather than
+// during the dashboard's server render.
+export function CheckoutSuccessRefresh() {
+  const router = useRouter();
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const refresh = async () => {
+      await refreshAuthkitSession();
+      if (cancelled) return;
+
+      // Drop the ?checkout=success marker and re-render with fresh entitlements.
+      router.replace('/dashboard');
+      router.refresh();
+    };
+
+    refresh();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [router]);
+
+  return null;
+}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -2,8 +2,13 @@ import { Box, Flex, Text, Heading } from '@radix-ui/themes';
 import { withAuth } from '@workos-inc/authkit-nextjs';
 import { redirect } from 'next/navigation';
 import { DashboardContainer } from '../components/layout/dashboard-container';
+import { CheckoutSuccessRefresh } from './checkout-success-refresh';
 
-export default async function DashboardPage() {
+export default async function DashboardPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ checkout?: string }>;
+}) {
   const session = await withAuth({ ensureSignedIn: true });
 
   // This view is restricted to admins
@@ -11,8 +16,11 @@ export default async function DashboardPage() {
     return redirect('/product');
   }
 
+  const { checkout } = await searchParams;
+
   return (
     <Flex direction="column" gap="3" width="100%">
+      {checkout === 'success' && <CheckoutSuccessRefresh />}
       <Box>
         <Heading>Dashboard</Heading>
       </Box>

--- a/src/app/router/route.ts
+++ b/src/app/router/route.ts
@@ -4,7 +4,7 @@ import { workos } from '../api/workos';
 import { NextRequest } from 'next/server';
 
 export const GET = async (request: NextRequest) => {
-  const { session } = await authkit(request);
+  let { session } = await authkit(request);
 
   if (!session || !session.user) {
     return redirect('/pricing');
@@ -19,7 +19,6 @@ export const GET = async (request: NextRequest) => {
     });
 
     if (oms.data.length > 0) {
-      // @ts-expect-error will be fixed in the next version of @workos-inc/authkit-nextjs
       session = await refreshSession({
         organizationId: oms.data[0].organizationId,
         ensureSignedIn: true,


### PR DESCRIPTION
## Summary

`scripts/setup.ts` created a Stripe webhook endpoint (subscribed to `checkout.session.completed`) pointed at `<convex-deployment>.site/stripe-webhook`, but `convex/http.ts` only ever registers a `/workos-webhook` route — there is no `/stripe-webhook` handler (git history confirms one was never committed). So setup wired up a **dead** Stripe endpoint, and the code implied you must run your own Stripe listener.

Entitlement sync does **not** depend on that webhook. With the WorkOS [Stripe integration](https://workos.com/docs/authkit/add-ons/stripe) enabled, WorkOS listens to Stripe and provisions [entitlements](https://workos.com/docs/user-management/entitlements) onto the org's access token once `stripeCustomerId` is set on the org (already done in `src/app/api/subscribe/route.ts`). The app's only responsibility is to **refresh the session after checkout** so new entitlements appear in the token immediately rather than on next login.

This PR removes the misleading dead webhook and makes the post-checkout refresh explicit.

### Changes

- **`scripts/setup.ts`**: Removed `setupStripeWebhook()` and its call. It also set `STRIPE_API_KEY` in Convex (read by `convex/stripe.ts`), so that one step is preserved in a small `setStripeApiKeyInConvex()` helper. `STRIPE_WEBHOOK_SECRET` is no longer set (only the dead handler would have used it). The `.cloud`→`.site` `webhookUrl` derivation is kept — it still feeds `setupWorkOSWebhook()`.
  ```diff
  - await setupStripeWebhook(STRIPE_API_KEY, webhookUrl + '/stripe-webhook');
  + await setStripeApiKeyInConvex(STRIPE_API_KEY);
    await setupWorkOSWebhook(WORKOS_API_KEY, webhookUrl + '/workos-webhook');
  ```

- **`src/app/api/subscribe/route.ts`**: Added a comment explaining WorkOS provisions entitlements automatically (no app-side Stripe webhook), and tagged the checkout `success_url` with a marker:
  ```diff
  - success_url: `${process.env.NEXT_PUBLIC_BASE_URL}/dashboard`,
  + success_url: `${process.env.NEXT_PUBLIC_BASE_URL}/dashboard?checkout=success`,
  ```

- **`src/app/dashboard/page.tsx` + new `checkout-success-refresh.tsx`**: When `?checkout=success` is present, refresh the AuthKit session so new entitlements land in the token now.
  - `refreshAuthkitSession` calls `refreshSession()`, which **sets cookies** — that throws during a Server Component render ("Cookies can only be modified in a Server Action or Route Handler"). The existing repo pattern (`src/app/dashboard/audit-logs/page.tsx`) invokes it from a **client** component in `useEffect`, so I matched that: a small `CheckoutSuccessRefresh` client component runs the action on mount, then `router.replace('/dashboard')` + `router.refresh()` to drop the marker and re-render with fresh entitlements. Verified `refreshAuthkitSession()` returns `Promise<string>` (a stringified session) and takes no args.

- **`README.md`**: Added one line — entitlement sync is handled by WorkOS; the only app responsibility is refreshing the session after checkout; no Stripe webhook required for entitlements.

### Incidental (unrelated) build fix

`next build` was already failing on `main` (verified on a clean tree) with an error in `src/app/router/route.ts`:
```
cannot reassign to a variable declared with `const`
```
`session` was destructured with `const` then reassigned under a `@ts-expect-error`. Turbopack treats const reassignment as a hard error, so the build was red. Changed `const { session }` → `let { session }` and removed the now-unused `@ts-expect-error` directive. This is unrelated to the webhook work but was necessary to get a green `lint`/`build`. Happy to split it out if preferred.

## Validation

- `eslint` — passes
- `tsc --noEmit` — passes
- `next build` — passes (with env vars set)

## Optional follow-up (not required for entitlements)

If app-side Stripe events are ever wanted (owning your own DB records, receipts, dunning, etc.), you could add a real `/stripe-webhook` Convex HTTP route and re-introduce the setup step + `STRIPE_WEBHOOK_SECRET`. Note `convex/stripe.ts` already contains an unused `verifyStripeWebhook` action that such a handler would use. This is explicitly **not required for entitlements** and intentionally left out of this PR.

Docs: https://workos.com/docs/authkit/add-ons/stripe · https://workos.com/docs/user-management/entitlements

Link to Devin session: https://app.devin.ai/sessions/0b653638165f422a9cb0808ecc0aff04
Requested by: @chaance